### PR TITLE
Fix description of rcbot_customloadouts cvar

### DIFF
--- a/utils/RCBot2_meta/bot_cvars.cpp
+++ b/utils/RCBot2_meta/bot_cvars.cpp
@@ -100,7 +100,7 @@ ConVar rcbot_tf2_payload_dist_retreat("rcbot_tf2_payload_dist_retreat","512.0",0
 ConVar rcbot_spy_runaway_health("rcbot_spy_runaway_health","70",0,"health which spies run away after attacking");
 ConVar rcbot_supermode("rcbot_supermode","0",0,"If 1 will make every bot skill and reaction much higher");
 ConVar rcbot_addbottime("rcbot_addbottime","3",0,"The time in seconds for bots to be added after another");
-ConVar rcbot_customloadouts("rcbot_customloadouts","0",0,"!!BROKEN RIGHT NOW!! - if 1 bots can use custom weapons");
+ConVar rcbot_customloadouts("rcbot_customloadouts","0",0,"Enable/disable custom loadouts for bots");
 ConVar rcbot_givenameditem_offset("rcbot_givenameditem_offset","471",0,"offset of the GiveNamedItem function");
 ConVar rcbot_equipwearable_offset("rcbot_equipwearable_offset","426",0,"offset of the EquipWearable function");
 ConVar rcbot_rmplayeritem_offset("rcbot_rmplayeritem_offset","270",0,"offset of the RemovePlayerItem function");


### PR DESCRIPTION
That convar works again with the actual hookinfo offsets.